### PR TITLE
Metrics IDB and Ignition Archive, fixes and improvements

### DIFF
--- a/src/main/kotlin/io/github/paulgriffith/kindling/idb/metrics/MetricCard.kt
+++ b/src/main/kotlin/io/github/paulgriffith/kindling/idb/metrics/MetricCard.kt
@@ -5,6 +5,8 @@ import io.github.paulgriffith.kindling.idb.metrics.MetricCard.Companion.MetricPr
 import io.github.paulgriffith.kindling.idb.metrics.MetricCard.Companion.MetricPresentation.Heap
 import io.github.paulgriffith.kindling.idb.metrics.MetricCard.Companion.MetricPresentation.Queue
 import io.github.paulgriffith.kindling.idb.metrics.MetricCard.Companion.MetricPresentation.Throughput
+import io.github.paulgriffith.kindling.utils.Action
+import io.github.paulgriffith.kindling.utils.jFrame
 import net.miginfocom.swing.MigLayout
 import org.jdesktop.swingx.border.DropShadowBorder
 import org.jfree.chart.ChartPanel
@@ -33,7 +35,22 @@ class MetricCard(val metric: Metric, data: List<MetricData>) : JPanel(MigLayout(
         /* print = */ false,
         /* zoom = */ true,
         /* tooltips = */ true,
-    )
+    ).apply {
+        popupMenu.addSeparator()
+        popupMenu.add(
+            Action("Popout") {
+                jFrame(
+                    title = metric.name,
+                    width = 800,
+                    height = 600,
+                ) {
+                    add(
+                        ChartPanel(sparkline(data, presentation.formatter))
+                    )
+                }
+            }
+        )
+    }
 
     init {
         add(

--- a/src/main/kotlin/io/github/paulgriffith/kindling/idb/metrics/MetricsView.kt
+++ b/src/main/kotlin/io/github/paulgriffith/kindling/idb/metrics/MetricsView.kt
@@ -29,7 +29,7 @@ class MetricsView(connection: Connection) : ToolPanel("ins 0, fill, hidemode 3")
     private val metricDataQuery = connection.prepareStatement(
         //language=sql
         """
-        SELECT 
+        SELECT DISTINCT
             VALUE,
             TIMESTAMP 
         FROM SYSTEM_METRICS

--- a/src/main/kotlin/io/github/paulgriffith/kindling/zip/ZipView.kt
+++ b/src/main/kotlin/io/github/paulgriffith/kindling/zip/ZipView.kt
@@ -32,6 +32,7 @@ import java.nio.file.spi.FileSystemProvider
 import javax.swing.Icon
 import javax.swing.JFileChooser
 import javax.swing.JLabel
+import javax.swing.JSplitPane
 import javax.swing.tree.TreeSelectionModel
 import javax.xml.XMLConstants
 import javax.xml.parsers.DocumentBuilderFactory
@@ -130,10 +131,11 @@ class ZipView(path: Path) : ToolPanel("ins 6, flowy") {
                     }
                     add(openIndividually)
 
-                    if (selectedPaths.size == 1) {
+                    val selectedNode = selectedPaths.first().lastPathComponent as PathNode
+
+                    if (selectedPaths.size == 1 && selectedNode.isLeaf) {
                         add(
                             Action("Save As") {
-                                val selectedNode = selectedPaths.first().lastPathComponent as PathNode
                                 exportFileChooser.selectedFile = File(selectedNode.userObject.name)
                                 if (exportFileChooser.showSaveDialog(this@attachPopupMenu) == JFileChooser.APPROVE_OPTION) {
                                     provider.newInputStream(selectedNode.userObject).use { file ->
@@ -148,8 +150,17 @@ class ZipView(path: Path) : ToolPanel("ins 6, flowy") {
         }
 
         add(bundleInfo, "split 2, height 32!")
-        add(FlatScrollPane(fileTree), "pushy, growy, width 250!")
-        add(tabStrip, "newline, push, grow, spany")
+        add(
+            JSplitPane(
+                JSplitPane.HORIZONTAL_SPLIT,
+                FlatScrollPane((fileTree)),
+                tabStrip,
+            ).apply {
+                dividerSize += 2
+                isOneTouchExpandable = true
+                dividerLocation = 250
+            }, "push, grow, span"
+        )
     }
 
     override val icon: Icon = ZipViewer.icon


### PR DESCRIPTION
ZD-748, ZD-660, ZD-542

- Metrics IDB charts now have a right click option to pop-out into a new window
- Project exports from the archive tool now export to a single .zip file which can be easily imported into Ignition
- "Save As" feature now works as intended
- Removed "Save As" ability when right clicking a directory.
- Fixed crash when metrics idb contained duplicate datapoints (same value & timestamp)