### PR TITLE
Preferences Panel - UI Customization and Session Saving

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ repositories {
 dependencies {
     // see gradle/libs.version.toml
     api(libs.serialization.json)
+    api(libs.kotlinreflect)
     api(libs.xerial.jdbc)
     api(libs.hsql)
     api(libs.zip4j)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-
 coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "coroutines" }
 serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.5.1" }
 xerial-jdbc = { group = "org.xerial", name = "sqlite-jdbc", version = "3.42.0.0" }
+kotlinreflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 logback = { group = "ch.qos.logback", name = "logback-classic", version = "1.4.7" }
 hsql = { group = "org.hsqldb", name = "hsqldb", version = "2.7.1" }
 zip4j = { group = "net.lingala.zip4j", name = "zip4j", version = "2.11.5" }
@@ -32,6 +33,7 @@ flatlaf-core = { group = "com.formdev", name = "flatlaf", version.ref = "flatlaf
 flatlaf-extras = { group = "com.formdev", name = "flatlaf-extras", version.ref = "flatlaf" }
 flatlaf-jide = { group = "com.formdev", name = "flatlaf-jide-oss", version.ref = "flatlaf" }
 flatlaf-swingx = { group = "com.formdev", name = "flatlaf-swingx", version.ref = "flatlaf" }
+flatlaf-themes = { group = "com.formdev", name = "flatlaf-intellij-themes", version.ref = "flatlaf" }
 svgSalamander = { group = "com.formdev", name = "svgSalamander", version = "1.1.4" }
 jide-common = { group = "com.formdev", name = "jide-oss", version = "3.7.12" }
 swingx = { group = "org.swinglabs.swingx", name = "swingx-all", version = "1.6.5-1" }
@@ -61,6 +63,7 @@ flatlaf = [
     "flatlaf-extras",
     "flatlaf-jide",
     "flatlaf-swingx",
+    "flatlaf-themes",
 ]
 kotest = [
     "kotest-junit",

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/cache/CacheView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/cache/CacheView.kt
@@ -11,9 +11,11 @@ import io.github.inductiveautomation.kindling.cache.model.AuditProfileData
 import io.github.inductiveautomation.kindling.cache.model.ScriptedSFData
 import io.github.inductiveautomation.kindling.core.Detail
 import io.github.inductiveautomation.kindling.core.DetailsPane
+import io.github.inductiveautomation.kindling.core.Savable
 import io.github.inductiveautomation.kindling.core.Tool
 import io.github.inductiveautomation.kindling.core.ToolOpeningException
 import io.github.inductiveautomation.kindling.core.ToolPanel
+import io.github.inductiveautomation.kindling.core.ToolPanelSurrogate
 import io.github.inductiveautomation.kindling.utils.Action
 import io.github.inductiveautomation.kindling.utils.EDT_SCOPE
 import io.github.inductiveautomation.kindling.utils.FlatScrollPane
@@ -31,7 +33,6 @@ import org.hsqldb.jdbc.JDBCDataSource
 import org.intellij.lang.annotations.Language
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
-import java.io.Serializable
 import java.nio.file.Files
 import java.nio.file.Path
 import java.sql.PreparedStatement
@@ -47,11 +48,13 @@ import kotlin.io.path.copyToRecursively
 import kotlin.io.path.extension
 import kotlin.io.path.name
 import kotlin.io.path.nameWithoutExtension
+import kotlinx.serialization.Serializable
+import kotlin.io.path.absolutePathString
 
 private const val TRANSACTION_GROUP_DATA = "Transaction Group Data"
 
 @OptIn(ExperimentalPathApi::class)
-class CacheView(private val path: Path) : ToolPanel() {
+class CacheView(private val path: Path) : ToolPanel(), Savable {
     private val tempDirectory: Path = Files.createTempDirectory(path.nameWithoutExtension)
 
     private val dbName = when (path.extension) {
@@ -100,6 +103,8 @@ class CacheView(private val path: Path) : ToolPanel() {
     override fun removeNotify() = super.removeNotify().also {
         connection.close()
     }
+
+    override fun save(): ToolPanelSurrogate = CacheViewSurrogate(path.absolutePathString())
 
     @Suppress("SqlNoDataSourceInspection", "SqlResolve")
     @Language("HSQLDB")
@@ -228,7 +233,7 @@ class CacheView(private val path: Path) : ToolPanel() {
         resizeWeight = 0.75
     }
 
-    private fun Serializable.toDetail(): Detail = when (this) {
+    private fun java.io.Serializable.toDetail(): Detail = when (this) {
         is BasicHistoricalRecord -> toDetail()
         is ScanclassHistorySet -> toDetail()
         is AuditProfileData -> toDetail()
@@ -261,13 +266,13 @@ class CacheView(private val path: Path) : ToolPanel() {
     /**
      * @throws ClassNotFoundException
      */
-    private fun ByteArray.deserialize(): Serializable {
+    private fun ByteArray.deserialize(): java.io.Serializable {
         return AliasingObjectInputStream(inputStream()) {
             put("com.inductiveautomation.ignition.gateway.audit.AuditProfileData", AuditProfileData::class.java)
             put("com.inductiveautomation.ignition.gateway.script.ialabs.IALabsDatasourceFunctions\$QuerySFData", ScriptedSFData::class.java)
 //            put("com.inductiveautomation.ignition.gateway.alarming.journal.DatabaseAlarmJournal\$AlarmJournalSFData", AlarmJournalData::class.java)
 //            put("com.inductiveautomation.ignition.gateway.alarming.journal.DatabaseAlarmJournal\$AlarmJournalSFGroup", AlarmJournalSFGroup::class.java)
-        }.readObject() as Serializable
+        }.readObject() as java.io.Serializable
     }
 
     private fun ScanclassHistorySet.toDetail(): Detail {
@@ -417,6 +422,7 @@ class CacheView(private val path: Path) : ToolPanel() {
         val LOGGER = getLogger<CacheView>()
         val cacheFileExtensions = listOf("data", "script", "log", "backup", "properties")
     }
+
 }
 
 object CacheViewer : Tool {
@@ -425,4 +431,9 @@ object CacheViewer : Tool {
     override val icon = FlatSVGIcon("icons/bx-data.svg")
     override val extensions = listOf("data", "script", "zip")
     override fun open(path: Path): ToolPanel = CacheView(path)
+}
+
+@Serializable
+class CacheViewSurrogate(val path: String) : ToolPanelSurrogate {
+    override fun load(): Savable = CacheView(Path.of(path))
 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/core/Kindling.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/core/Kindling.kt
@@ -4,10 +4,30 @@ import com.formdev.flatlaf.FlatDarkLaf
 import com.formdev.flatlaf.FlatLaf
 import com.formdev.flatlaf.FlatLightLaf
 import com.formdev.flatlaf.extras.FlatAnimatedLafChange
+import com.formdev.flatlaf.intellijthemes.FlatAllIJThemes
 import com.formdev.flatlaf.themes.FlatMacDarkLaf
 import com.formdev.flatlaf.themes.FlatMacLightLaf
 import com.formdev.flatlaf.util.SystemInfo
 import com.jthemedetecor.OsThemeDetector
+import io.github.inductiveautomation.kindling.cache.CacheViewSurrogate
+import io.github.inductiveautomation.kindling.idb.IdbViewSurrogate
+import io.github.inductiveautomation.kindling.thread.MultiThreadViewSurrogate
+import io.github.inductiveautomation.kindling.zip.ZipViewSurrogate
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Polymorphic
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import kotlinx.serialization.json.encodeToStream
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea
 import org.jfree.chart.JFreeChart
 import java.awt.Image
@@ -15,25 +35,130 @@ import java.awt.Toolkit
 import java.io.File
 import javax.swing.UIManager
 import kotlin.io.path.Path
-import kotlin.properties.Delegates
+import kotlin.io.path.createDirectory
+import kotlin.io.path.inputStream
+import kotlin.io.path.notExists
+import kotlin.io.path.outputStream
+import kotlin.reflect.full.createInstance
 import org.fife.ui.rsyntaxtextarea.Theme as RSyntaxTheme
 
+@OptIn(ExperimentalSerializationApi::class)
 object Kindling {
     val homeLocation: File = Path(System.getProperty("user.home"), "Downloads").toFile()
 
+    val cacheLocation = Path(System.getProperty("user.home"), ".kindling").also {
+        if (it.notExists()) it.createDirectory()
+    }
+
     val frameIcon: Image = Toolkit.getDefaultToolkit().getImage(this::class.java.getResource("/icons/kindling.png"))
 
-    @Suppress("ktlint:trailing-comma-on-declaration-site")
-    enum class Theme(val lookAndFeel: FlatLaf, private val rSyntaxThemeName: String) {
-        Light(
-            lookAndFeel = if (SystemInfo.isMacOS) FlatMacLightLaf() else FlatLightLaf(),
-            rSyntaxThemeName = "idea.xml",
-        ),
-        Dark(
-            lookAndFeel = if (SystemInfo.isMacOS) FlatMacDarkLaf() else FlatDarkLaf(),
-            rSyntaxThemeName = "dark.xml",
-        );
+    val savableFormat = Json { serializersModule = savableModule }
 
+    private val themeListeners = mutableListOf<(Theme) -> Unit>()
+
+    private val themeDetector = OsThemeDetector.getDetector()
+
+    fun addThemeChangeListener(listener: (Theme) -> Unit) {
+        themeListeners.add(listener)
+    }
+
+    fun initTheme() {
+        session.theme.apply(false)
+    }
+
+    private fun Theme.apply(animate: Boolean) {
+        try {
+            if (animate) {
+                FlatAnimatedLafChange.showSnapshot()
+            }
+            UIManager.setLookAndFeel(lookAndFeel)
+            FlatLaf.updateUI()
+        } finally {
+            // Will no-op if not animated
+            FlatAnimatedLafChange.hideSnapshotWithAnimation()
+        }
+    }
+
+    val session: UserSession = run {
+        try {
+            val session: UserSession = cacheLocation.resolve(UserSession.sessionFile).inputStream().use(Json::decodeFromStream)
+            // Throw away the newly created theme instance and grab a copy of what we have from Theme.companion
+            session.apply {
+                theme = (Theme.lightThemes + Theme.darkThemes).find { it.name == theme.name } ?: Theme.defaultTheme
+            }
+        } catch (e: Exception) { // A few exceptions can happen here. Fallback to default session.
+            UserSession()
+        }
+    }
+
+    @Serializable
+    class UserSession {
+
+        var saveAndResume: Boolean = true
+
+        var theme = Theme.defaultTheme
+            set(newValue) {
+                field = newValue
+                newValue.apply(true)
+                for (listener in themeListeners) {
+                    listener.invoke(newValue)
+                }
+            }
+
+        var showFullLoggerNames = false
+
+        var uiScaleFactor = 1.0
+
+        fun saveSession() {
+            val sessionOutput = cacheLocation.resolve(sessionFile)
+
+            sessionOutput.outputStream().use {
+                savableFormat.encodeToStream(this, it)
+            }
+        }
+
+        companion object {
+            const val sessionFile = "session.json"
+            const val toolsFile = "tools.json"
+
+            private val savableJsonFormat = Json { serializersModule = savableModule }
+
+            fun savePanels(savablePanels: List<ToolPanelSurrogate>) {
+                if (session.saveAndResume) {
+                    val out = cacheLocation.resolve(toolsFile).outputStream()
+
+                    out.use { os ->
+                        savableJsonFormat.encodeToStream(savablePanels, os)
+                    }
+                }
+            }
+
+            fun loadPanels(): List<Savable> {
+                return if (session.saveAndResume) {
+                    try {
+                        cacheLocation.resolve(toolsFile).inputStream().use {
+                            val surrogates = savableJsonFormat.decodeFromStream<List<ToolPanelSurrogate>>(it)
+                            surrogates.map(ToolPanelSurrogate::load)
+                        }
+                    } catch (e: Exception) {
+                        emptyList()
+                    }
+                } else {
+                    emptyList()
+                }
+            }
+        }
+    }
+
+    @Suppress("ktlint:trailing-comma-on-declaration-site")
+    @Serializable
+    class Theme(
+        val name: String,
+        @Serializable(with=LafSerializer::class)
+        val lookAndFeel: FlatLaf,
+        val isDark: Boolean,
+        private val rSyntaxThemeName: String
+    ) {
         private val rSyntaxTheme: RSyntaxTheme by lazy {
             RSyntaxTheme::class.java.getResourceAsStream("themes/$rSyntaxThemeName").use(org.fife.ui.rsyntaxtextarea.Theme::load)
         }
@@ -50,37 +175,71 @@ object Kindling {
             }
             chart.backgroundPaint = UIManager.getColor("Panel.background")
         }
-    }
 
-    private val themeListeners = mutableListOf<(Theme) -> Unit>()
+        companion object {
+            private val defaultDark = Theme(
+                name = "Default Dark",
+                lookAndFeel = if (SystemInfo.isMacOS) FlatMacDarkLaf() else FlatDarkLaf(),
+                isDark = true,
+                rSyntaxThemeName = "dark.xml",
+            )
+            private val defaultLight = Theme(
+                name = "Default Light",
+                lookAndFeel = if (SystemInfo.isMacOS) FlatMacLightLaf() else FlatLightLaf(),
+                isDark = false,
+                rSyntaxThemeName = "idea.xml",
+            )
 
-    fun addThemeChangeListener(listener: (Theme) -> Unit) {
-        themeListeners.add(listener)
-    }
-
-    private val themeDetector = OsThemeDetector.getDetector()
-
-    var theme: Theme by Delegates.observable(if (themeDetector.isDark) Theme.Dark else Theme.Light) { _, _, newValue ->
-        newValue.apply(true)
-        for (listener in themeListeners) {
-            listener.invoke(newValue)
-        }
-    }
-
-    fun initTheme() {
-        theme.apply(false)
-    }
-
-    private fun Theme.apply(animate: Boolean) {
-        try {
-            if (animate) {
-                FlatAnimatedLafChange.showSnapshot()
+            val lightThemes = listOf(defaultLight) + FlatAllIJThemes.INFOS.filter { !it.isDark }.map { info ->
+                Theme(
+                    name = info.name,
+                    lookAndFeel = Class.forName(info.className).kotlin.createInstance() as FlatLaf,
+                    isDark = info.isDark,
+                    rSyntaxThemeName = "idea.xml",
+                )
             }
-            UIManager.setLookAndFeel(lookAndFeel)
-            FlatLaf.updateUI()
-        } finally {
-            // Will no-op if not animated
-            FlatAnimatedLafChange.hideSnapshotWithAnimation()
+
+            val darkThemes = listOf(defaultDark) + FlatAllIJThemes.INFOS.filter { it.isDark }.map { info ->
+                Theme(
+                    name = info.name,
+                    lookAndFeel = Class.forName(info.className).kotlin.createInstance() as FlatLaf,
+                    isDark = info.isDark,
+                    rSyntaxThemeName = "dark.xml",
+                )
+            }
+
+            val defaultTheme = if (themeDetector.isDark) defaultDark else defaultLight
         }
+    }
+}
+
+interface Savable {
+    fun save(): ToolPanelSurrogate
+}
+
+@Polymorphic
+interface ToolPanelSurrogate {
+    fun load(): Savable
+}
+
+val savableModule = SerializersModule {
+    polymorphic(ToolPanelSurrogate::class) {
+        subclass(MultiThreadViewSurrogate::class)
+        subclass(IdbViewSurrogate::class)
+        subclass(CacheViewSurrogate::class)
+        subclass(ZipViewSurrogate::class)
+    }
+}
+
+object LafSerializer : KSerializer<FlatLaf> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("FlatLaf", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: FlatLaf) {
+        encoder.encodeString(value::class.qualifiedName!!) // Class will not be local or within an anonymous object
+    }
+
+    override fun deserialize(decoder: Decoder): FlatLaf {
+        val className = decoder.decodeString()
+        return Class.forName(className).kotlin.createInstance() as FlatLaf
     }
 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/core/PreferencesPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/core/PreferencesPanel.kt
@@ -1,0 +1,173 @@
+package io.github.inductiveautomation.kindling.core
+
+import io.github.inductiveautomation.kindling.utils.configureCellRenderer
+import net.miginfocom.swing.MigLayout
+import java.awt.event.ItemEvent
+import javax.swing.BorderFactory
+import javax.swing.DefaultComboBoxModel
+import javax.swing.JButton
+import javax.swing.JCheckBox
+import javax.swing.JComboBox
+import javax.swing.JFrame
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JSpinner
+import javax.swing.JToggleButton
+import javax.swing.SpinnerNumberModel
+import javax.swing.UIManager
+
+class PreferencesPanel : JFrame("Preferences") {
+
+    private val uiPanel = UIPanel()
+
+    private val generalPanel = GeneralPanel()
+
+    private val submitButton = JButton("OK").apply {
+        addActionListener {
+            this@PreferencesPanel.isVisible = false
+            saveChanges()
+        }
+    }
+
+    private val cancelButton = JButton("Cancel").apply {
+        isDefaultCapable = false
+        addActionListener {
+            this@PreferencesPanel.isVisible = false
+        }
+    }
+
+    init {
+        setSize(800, 600)
+        iconImage = Kindling.frameIcon
+        defaultCloseOperation = HIDE_ON_CLOSE
+        setLocationRelativeTo(null)
+
+        contentPane = JPanel(MigLayout("fillx, ins 10, gap 10")).apply {
+            add(uiPanel, "push, grow")
+            add(generalPanel, "grow, wrap")
+            add(
+                JPanel(MigLayout("fill, ins 10")).apply {
+                    add(cancelButton, "east, gapright 10")
+                    add(submitButton, "east, gapright 10")
+                },
+                "south, gapbottom 10"
+            )
+        }
+        pack()
+    }
+
+    private fun saveChanges() {
+        Kindling.session.showFullLoggerNames = generalPanel.showFullLoggerNames.isSelected
+        Kindling.session.saveAndResume = generalPanel.sessionResume.isSelected
+        Kindling.session.uiScaleFactor = uiPanel.uiScaleSelector.value as Double
+
+        if (Kindling.session.theme != uiPanel.themeSelection.selectedItem) {
+            Kindling.session.theme = uiPanel.themeSelection.selectedItem
+        }
+    }
+
+    class UIPanel : JPanel(MigLayout("fill, gap 10")) {
+        private val lightDarkToggle = JToggleButton().apply {
+            if (Kindling.session.theme.isDark) {
+                isSelected = false
+                text = "Dark Themes"
+            } else {
+                isSelected = true
+                text = "Light Themes"
+            }
+
+            addItemListener { event ->
+                text = if (event.stateChange == ItemEvent.SELECTED) "Light Themes" else "Dark Themes"
+            }
+        }
+
+        val themeSelection = ThemeSelectionDropdown()
+
+        val uiScaleSelector = JSpinner(
+            SpinnerNumberModel(Kindling.session.uiScaleFactor, 1.0, 2.0, 0.1)
+        )
+
+        init {
+            border = BorderFactory.createTitledBorder("Appearance/UI")
+
+            val themeLabel = JLabel("Theme")
+            val uiScaleLabel = JLabel("UI Scale (Requires restart)")
+
+            add(themeLabel, "grow")
+            add(lightDarkToggle)
+            add(themeSelection, "grow, wrap")
+
+            add(uiScaleLabel)
+            add(uiScaleSelector)
+        }
+
+        inner class ThemeSelectionDropdown private constructor(
+            private val lightThemes: Array<Kindling.Theme>,
+            private val darkThemes: Array<Kindling.Theme>,
+        ) : JComboBox<Kindling.Theme>() {
+
+            constructor() : this(Kindling.Theme.lightThemes.toTypedArray(), Kindling.Theme.darkThemes.toTypedArray())
+
+            init {
+                val initialTheme = Kindling.session.theme
+                select(initialTheme)
+
+                configureCellRenderer { _, value, _, _, _ ->
+                    text = value?.name
+                }
+
+                lightDarkToggle.addItemListener { event ->
+                    model = if (event.stateChange == ItemEvent.SELECTED) {
+                        DefaultComboBoxModel(lightThemes)
+                    } else {
+                        DefaultComboBoxModel(darkThemes)
+                    }
+                    setLafForSelectedItem()
+                }
+
+                addActionListener {
+                    setLafForSelectedItem()
+                }
+
+                Kindling.addThemeChangeListener { newTheme ->
+                    select(newTheme)
+                    setLafForSelectedItem()
+                }
+            }
+
+            override fun getSelectedItem(): Kindling.Theme = super.getSelectedItem() as Kindling.Theme
+
+            private fun setLafForSelectedItem() {
+                val oldLaf = UIManager.getLookAndFeel()
+                UIManager.setLookAndFeel(selectedItem.lookAndFeel)
+                updateUI()
+                UIManager.setLookAndFeel(oldLaf)
+            }
+
+            private fun select(theme: Kindling.Theme) {
+                model = if (theme.isDark) {
+                    DefaultComboBoxModel(darkThemes)
+                } else {
+                    DefaultComboBoxModel(lightThemes)
+                }
+                selectedItem = theme
+            }
+        }
+    }
+
+    class GeneralPanel : JPanel(MigLayout("fill, ins 10")) {
+        val sessionResume = JCheckBox("Resume session on relaunch").apply {
+            isSelected = Kindling.session.saveAndResume
+        }
+
+        val showFullLoggerNames = JCheckBox("Show full logger names by default").apply {
+            isSelected = Kindling.session.showFullLoggerNames
+        }
+
+        init {
+            border = BorderFactory.createTitledBorder("General")
+            add(sessionResume, "wrap")
+            add(showFullLoggerNames)
+        }
+    }
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/idb/IdbView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/idb/IdbView.kt
@@ -1,8 +1,10 @@
 package io.github.inductiveautomation.kindling.idb
 
 import com.formdev.flatlaf.extras.FlatSVGIcon
+import io.github.inductiveautomation.kindling.core.Savable
 import io.github.inductiveautomation.kindling.core.Tool
 import io.github.inductiveautomation.kindling.core.ToolPanel
+import io.github.inductiveautomation.kindling.core.ToolPanelSurrogate
 import io.github.inductiveautomation.kindling.idb.generic.GenericView
 import io.github.inductiveautomation.kindling.idb.metrics.MetricsView
 import io.github.inductiveautomation.kindling.log.Level
@@ -11,12 +13,14 @@ import io.github.inductiveautomation.kindling.log.SystemLogsEvent
 import io.github.inductiveautomation.kindling.utils.SQLiteConnection
 import io.github.inductiveautomation.kindling.utils.TabStrip
 import io.github.inductiveautomation.kindling.utils.toList
+import kotlinx.serialization.Serializable
 import java.nio.file.Path
 import java.sql.Connection
 import java.time.Instant
+import kotlin.io.path.absolutePathString
 import kotlin.io.path.name
 
-class IdbView(path: Path) : ToolPanel() {
+class IdbView(val path: Path) : ToolPanel(), Savable {
     private val connection = SQLiteConnection(path)
 
     private val tables: List<String> = connection.metaData.getTables("", "", "", null).toList { rs ->
@@ -63,6 +67,8 @@ class IdbView(path: Path) : ToolPanel() {
         super.removeNotify()
         connection.close()
     }
+
+    override fun save(): ToolPanelSurrogate = IdbViewSurrogate(path.absolutePathString())
 }
 
 enum class IdbTool {
@@ -169,4 +175,9 @@ object IdbViewer : Tool {
     override val icon = FlatSVGIcon("icons/bx-hdd.svg")
     override val extensions = listOf("idb")
     override fun open(path: Path): ToolPanel = IdbView(path)
+}
+
+@Serializable
+class IdbViewSurrogate(val path: String) : ToolPanelSurrogate {
+    override fun load(): Savable = IdbView(Path.of(path))
 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/idb/metrics/Sparkline.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/idb/metrics/Sparkline.kt
@@ -45,7 +45,7 @@ fun sparkline(data: List<MetricData>, formatter: NumberFormat): JFreeChart {
         padding = RectangleInsets(10.0, 10.0, 10.0, 10.0)
         isBorderVisible = false
 
-        Kindling.theme.apply(this)
+        Kindling.session.theme.apply(this)
         Kindling.addThemeChangeListener { theme ->
             theme.apply(this)
         }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/Header.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/Header.kt
@@ -3,6 +3,7 @@ package io.github.inductiveautomation.kindling.log
 import com.formdev.flatlaf.extras.FlatSVGIcon
 import com.jidesoft.swing.JideButton
 import com.jidesoft.swing.JidePopupMenu
+import io.github.inductiveautomation.kindling.core.Kindling
 import net.miginfocom.swing.MigLayout
 import org.jdesktop.swingx.JXSearchField
 import java.awt.event.MouseAdapter
@@ -21,7 +22,7 @@ class Header(private val totalRows: Int) : JPanel(MigLayout("ins 0, fill")) {
 
     val search = JXSearchField("Search")
 
-    var isShowFullLoggerName: Boolean by Delegates.observable(false) { property, oldValue, newValue ->
+    var isShowFullLoggerName: Boolean by Delegates.observable(Kindling.session.showFullLoggerNames) { property, oldValue, newValue ->
         firePropertyChange(property.name, oldValue, newValue)
     }
 
@@ -35,7 +36,7 @@ class Header(private val totalRows: Int) : JPanel(MigLayout("ins 0, fill")) {
 
     private val settingsMenu = JidePopupMenu().apply {
         add(
-            JCheckBoxMenuItem("Show Full Logger Names").apply {
+            JCheckBoxMenuItem("Show Full Logger Names", Kindling.session.showFullLoggerNames).apply {
                 addActionListener {
                     isShowFullLoggerName = !isShowFullLoggerName
                 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/LoggerNames.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/LoggerNames.kt
@@ -2,6 +2,7 @@ package io.github.inductiveautomation.kindling.log
 
 import com.formdev.flatlaf.extras.FlatSVGIcon
 import com.jidesoft.swing.CheckBoxList
+import io.github.inductiveautomation.kindling.core.Kindling
 import io.github.inductiveautomation.kindling.utils.Action
 import io.github.inductiveautomation.kindling.utils.FlatScrollPane
 import io.github.inductiveautomation.kindling.utils.NoSelectionModel
@@ -31,7 +32,7 @@ class LoggerNamesModel(val data: List<LoggerName>) : AbstractListModel<Any>() {
 }
 
 class LoggerNamesList(model: LoggerNamesModel) : CheckBoxList(model) {
-    var isShowFullLoggerName = false
+    var isShowFullLoggerName = Kindling.session.showFullLoggerNames
         set(value) {
             field = value
             repaint()

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/thread/MultiThreadView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/thread/MultiThreadView.kt
@@ -7,8 +7,10 @@ import io.github.inductiveautomation.kindling.core.ClipboardTool
 import io.github.inductiveautomation.kindling.core.Detail
 import io.github.inductiveautomation.kindling.core.Detail.BodyLine
 import io.github.inductiveautomation.kindling.core.MultiTool
+import io.github.inductiveautomation.kindling.core.Savable
 import io.github.inductiveautomation.kindling.core.ToolOpeningException
 import io.github.inductiveautomation.kindling.core.ToolPanel
+import io.github.inductiveautomation.kindling.core.ToolPanelSurrogate
 import io.github.inductiveautomation.kindling.core.add
 import io.github.inductiveautomation.kindling.thread.FilterModel.Companion.byCountAsc
 import io.github.inductiveautomation.kindling.thread.FilterModel.Companion.byCountDesc
@@ -16,6 +18,7 @@ import io.github.inductiveautomation.kindling.thread.FilterModel.Companion.byNam
 import io.github.inductiveautomation.kindling.thread.FilterModel.Companion.byNameDesc
 import io.github.inductiveautomation.kindling.thread.model.Stacktrace
 import io.github.inductiveautomation.kindling.thread.model.Thread
+import io.github.inductiveautomation.kindling.thread.model.ThreadColumnIdentifier
 import io.github.inductiveautomation.kindling.thread.model.ThreadDump
 import io.github.inductiveautomation.kindling.thread.model.ThreadLifespan
 import io.github.inductiveautomation.kindling.thread.model.ThreadModel
@@ -33,6 +36,7 @@ import io.github.inductiveautomation.kindling.utils.selectedRowIndices
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
 import net.miginfocom.swing.MigLayout
 import org.jdesktop.swingx.JXSearchField
 import org.jdesktop.swingx.decorator.ColorHighlighter
@@ -60,15 +64,15 @@ import kotlin.io.path.nameWithoutExtension
 import kotlin.io.path.outputStream
 
 class MultiThreadView(
-    private val paths: List<Path>,
-) : ToolPanel() {
+    val paths: List<Path>,
+) : ToolPanel(), Savable {
     private val threadDumps = paths.map { path ->
         ThreadDump.fromStream(path.inputStream()) ?: throw ToolOpeningException("Failed to open $path as a thread dump")
     }
 
-    private val poolList = FilterList("(No Pool)")
-    private val systemList = FilterList("Unassigned")
-    private val stateList = FilterList("")
+    val poolList = FilterList("(No Pool)")
+    val systemList = FilterList("Unassigned")
+    val stateList = FilterList("")
     private val searchField = JXSearchField("Search")
 
     private var visibleThreadDumps: List<ThreadDump?> = emptyList()
@@ -91,7 +95,7 @@ class MultiThreadView(
             }
         }
 
-    private val mainTable: ReifiedJXTable<ThreadModel> = run {
+    val mainTable: ReifiedJXTable<ThreadModel> = run {
         // populate initial state of all the filter lists
         visibleThreadDumps = threadDumps
         val initialModel = ThreadModel(currentLifespanList)
@@ -198,7 +202,7 @@ class MultiThreadView(
 
     private var comparison = ThreadComparisonPane(threadDumps.size, threadDumps[0].version)
 
-    private val threadDumpCheckboxList = ThreadDumpCheckboxList(paths).apply {
+    val threadDumpCheckboxList = ThreadDumpCheckboxList(paths).apply {
         isVisible = !mainTable.model.isSingleContext
     }
 
@@ -356,7 +360,7 @@ class MultiThreadView(
             add(sortButton(NATURAL_SORT_DESCENDING, "Sort Z-A", byNameDesc))
         }
 
-        add(JLabel("Version: ${threadDumps[0].version}"))
+        add(JLabel("Version: ${threadDumps.first().version}"))
         add(threadDumpCheckboxList, "gapleft 20px, pushx, growx, shpx 200")
         add(exportButton, "gapright 8")
         add(searchField, "wmin 300, wrap")
@@ -420,6 +424,20 @@ class MultiThreadView(
             }
         }
     }
+
+    override fun save() : ToolPanelSurrogate {
+        val sortedColumn = mainTable.sortedColumn.identifier as ThreadColumnIdentifier
+        return MultiThreadViewSurrogate(
+            paths = paths.map { it.toString() },
+            threadDumpSelectedIndices = threadDumpCheckboxList.checkBoxListSelectedIndices.toTypedArray(),
+            stateFilterSelectedIndices = poolList.checkBoxListSelectedIndices.toTypedArray(),
+            systemFilterSelectedIndices = systemList.checkBoxListSelectedIndices.toTypedArray(),
+            poolFilterSelectedIndices = poolList.checkBoxListSelectedIndices.toTypedArray(),
+            sortedColumn = sortedColumn,
+            sortOrder = mainTable.getSortOrder(sortedColumn),
+        )
+    }
+
 
     companion object {
         private val BACKGROUND = CoroutineScope(Dispatchers.Default)
@@ -519,5 +537,26 @@ object MultiThreadViewer : MultiTool, ClipboardTool {
             tempFile.outputStream().use(threadDump::copyTo)
         }
         return open(tempFile)
+    }
+}
+
+@Serializable
+class MultiThreadViewSurrogate(
+    val paths: List<String>,
+    val threadDumpSelectedIndices: Array<Int>,
+    val stateFilterSelectedIndices: Array<Int>,
+    val systemFilterSelectedIndices: Array<Int>,
+    val poolFilterSelectedIndices: Array<Int>,
+    val sortedColumn: ThreadColumnIdentifier,
+    val sortOrder: SortOrder,
+) : ToolPanelSurrogate {
+    override fun load(): Savable {
+        return MultiThreadView(paths.map(Path::of)).apply {
+            threadDumpCheckboxList.checkBoxListSelectedIndices = threadDumpSelectedIndices.toIntArray()
+            poolList.checkBoxListSelectedIndices = poolFilterSelectedIndices.toIntArray()
+            stateList.checkBoxListSelectedIndices = stateFilterSelectedIndices.toIntArray()
+            systemList.checkBoxListSelectedIndices = systemFilterSelectedIndices.toIntArray()
+            mainTable.setSortOrder(sortedColumn, sortOrder)
+        }
     }
 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/swing.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/swing.kt
@@ -28,6 +28,7 @@ import java.util.EventListener
 import javax.swing.DefaultListCellRenderer
 import javax.swing.DefaultListSelectionModel
 import javax.swing.Icon
+import javax.swing.JComboBox
 import javax.swing.JComponent
 import javax.swing.JFileChooser
 import javax.swing.JFrame
@@ -40,6 +41,7 @@ import javax.swing.ListCellRenderer
 import javax.swing.UIManager
 import javax.swing.event.EventListenerList
 import javax.swing.filechooser.FileFilter
+import javax.swing.plaf.basic.BasicComboBoxRenderer
 import javax.swing.table.TableModel
 import javax.swing.text.Document
 import javax.swing.tree.DefaultTreeCellRenderer
@@ -361,5 +363,26 @@ inline fun jFrame(title: String, width: Int, height: Int, block: JFrame.() -> Un
         block()
 
         isVisible = true
+    }
+}
+
+inline fun <reified T> JComboBox<T>.configureCellRenderer(
+    configureDefault: Boolean = true,
+    noinline block: BasicComboBoxRenderer.(list: JList<*>?, value: T?, index: Int, isSelected: Boolean, cellHasFocus: Boolean) -> Unit
+) {
+    renderer = object : BasicComboBoxRenderer() {
+        override fun getListCellRendererComponent(
+            list: JList<*>?,
+            value: Any?,
+            index: Int,
+            isSelected: Boolean,
+            cellHasFocus: Boolean
+        ): Component {
+            if (configureDefault) {
+                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus)
+            }
+            block(list, value as T?, index, isSelected, cellHasFocus)
+            return this
+        }
     }
 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/zip/ZipView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/zip/ZipView.kt
@@ -3,9 +3,11 @@ package io.github.inductiveautomation.kindling.zip
 import com.formdev.flatlaf.extras.FlatSVGIcon
 import com.formdev.flatlaf.extras.components.FlatPopupMenu
 import com.formdev.flatlaf.extras.components.FlatTabbedPane
+import io.github.inductiveautomation.kindling.core.Savable
 import io.github.inductiveautomation.kindling.core.Tool
 import io.github.inductiveautomation.kindling.core.ToolOpeningException
 import io.github.inductiveautomation.kindling.core.ToolPanel
+import io.github.inductiveautomation.kindling.core.ToolPanelSurrogate
 import io.github.inductiveautomation.kindling.utils.Action
 import io.github.inductiveautomation.kindling.utils.FlatScrollPane
 import io.github.inductiveautomation.kindling.utils.PathNode
@@ -22,6 +24,7 @@ import io.github.inductiveautomation.kindling.zip.views.PathView
 import io.github.inductiveautomation.kindling.zip.views.ProjectView
 import io.github.inductiveautomation.kindling.zip.views.TextFileView
 import io.github.inductiveautomation.kindling.zip.views.ToolView
+import kotlinx.serialization.Serializable
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.io.File
@@ -36,13 +39,14 @@ import javax.swing.JSplitPane
 import javax.swing.tree.TreeSelectionModel
 import javax.xml.XMLConstants
 import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.io.path.absolutePathString
 import kotlin.io.path.extension
 import kotlin.io.path.fileSize
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.name
 import kotlin.io.path.outputStream
 
-class ZipView(path: Path) : ToolPanel("ins 6, flowy") {
+class ZipView(private val path: Path) : ToolPanel("ins 6, flowy"), Savable {
     private val zipFile: FileSystem = FileSystems.newFileSystem(path)
     private val provider: FileSystemProvider = zipFile.provider()
 
@@ -166,6 +170,8 @@ class ZipView(path: Path) : ToolPanel("ins 6, flowy") {
 
     override val icon: Icon = ZipViewer.icon
 
+    override fun save(): ToolPanelSurrogate = ZipViewSurrogate(path.absolutePathString())
+
     private fun maybeAddNewTab(vararg paths: Path) {
         val pathList = paths.toList()
         val existingTab = tabStrip.tabs.find { tab -> tab.paths == pathList }
@@ -228,4 +234,9 @@ object ZipViewer : Tool {
     }
 
     private val logger = getLogger<ZipViewer>()
+}
+
+@Serializable
+class ZipViewSurrogate(val path: String) : ToolPanelSurrogate {
+    override fun load(): Savable = ZipView(Path.of(path))
 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/zip/views/TextFileView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/zip/views/TextFileView.kt
@@ -25,7 +25,7 @@ class TextFileView(override val provider: FileSystemProvider, override val path:
         isEditable = false
         syntaxEditingStyle = KNOWN_EXTENSIONS[path.extension] ?: SYNTAX_STYLE_NONE
 
-        Kindling.theme.apply(this)
+        Kindling.session.theme.apply(this)
     }
 
     override val icon: FlatSVGIcon = FlatSVGIcon("icons/bx-file.svg").derive(16, 16)


### PR DESCRIPTION
This commit aims to lay groundwork for a general user-preferences panel and the ability to save the user's last open session. It also introduces accessibility features (requested internal) for UI Scaling and various color themes for color-deficient or low-vision users.

- Preferences panel has basic interface for changing the theme, UI Scaling, session resuming, and "Show full logger names" option.
- Number of themes expanded significantly
- Interfaces created to implement serializing views via a surrogate class*

_*This feature is not available for Wrapper logs yet._