### PR TITLE
Harmonized filtering UI

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/core/FilterPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/core/FilterPanel.kt
@@ -1,0 +1,32 @@
+package io.github.inductiveautomation.kindling.core
+
+import io.github.inductiveautomation.kindling.utils.Column
+import java.util.EventListener
+import javax.swing.JComponent
+import javax.swing.JPopupMenu
+
+interface FilterPanel<T> : Filter<T> {
+    val tabName: String
+    fun isFilterApplied(): Boolean
+    val component: JComponent
+    fun addFilterChangeListener(listener: FilterChangeListener)
+
+    fun reset()
+
+    fun customizePopupMenu(
+        menu: JPopupMenu,
+        column: Column<out T, *>,
+        event: T,
+    ) = Unit
+}
+
+fun interface Filter<T> {
+    /**
+     * Return true if this filter should display this event.
+     */
+    fun filter(event: T): Boolean
+}
+
+fun interface FilterChangeListener : EventListener {
+    fun filterChanged()
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/core/FilterPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/core/FilterPanel.kt
@@ -1,30 +1,37 @@
 package io.github.inductiveautomation.kindling.core
 
 import io.github.inductiveautomation.kindling.utils.Column
+import io.github.inductiveautomation.kindling.utils.add
 import java.util.EventListener
 import javax.swing.JComponent
 import javax.swing.JPopupMenu
+import javax.swing.event.EventListenerList
 
-interface FilterPanel<T> : Filter<T> {
-    val tabName: String
-    fun isFilterApplied(): Boolean
-    val component: JComponent
-    fun addFilterChangeListener(listener: FilterChangeListener)
+abstract class FilterPanel<T> : Filter<T> {
+    abstract val tabName: String
+    abstract fun isFilterApplied(): Boolean
+    abstract val component: JComponent
 
-    fun reset()
+    protected val listeners = EventListenerList()
+    fun addFilterChangeListener(listener: FilterChangeListener) {
+        listeners.add(listener)
+    }
 
-    fun customizePopupMenu(
+    abstract fun reset()
+
+    abstract fun customizePopupMenu(
         menu: JPopupMenu,
         column: Column<out T, *>,
         event: T,
-    ) = Unit
+    )
+
 }
 
 fun interface Filter<T> {
     /**
      * Return true if this filter should display this event.
      */
-    fun filter(event: T): Boolean
+    fun filter(item: T): Boolean
 }
 
 fun interface FilterChangeListener : EventListener {

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/core/FilterSidebar.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/core/FilterSidebar.kt
@@ -40,6 +40,8 @@ class FilterSidebar<T>(
                 )
             }
         }
+
+        selectedIndex = 0
     }
 
     private fun FilterPanel<*>.updateTabState() {

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/core/FilterSidebar.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/core/FilterSidebar.kt
@@ -1,0 +1,63 @@
+package io.github.inductiveautomation.kindling.core
+
+import com.formdev.flatlaf.extras.components.FlatTabbedPane
+import io.github.inductiveautomation.kindling.utils.Action
+import io.github.inductiveautomation.kindling.utils.attachPopupMenu
+import javax.swing.JPopupMenu
+
+class FilterSidebar<T>(
+    vararg panels: FilterPanel<T>?,
+    ) : FlatTabbedPane() {
+
+    val filterPanels = panels.filterNotNull()
+
+    init {
+        tabLayoutPolicy = SCROLL_TAB_LAYOUT
+        tabsPopupPolicy = TabsPopupPolicy.asNeeded
+        scrollButtonsPolicy = ScrollButtonsPolicy.never
+        tabWidthMode = TabWidthMode.equal
+        tabType = TabType.underlined
+        tabHeight = 16
+
+        filterPanels.forEachIndexed { i, filterPanel ->
+            addTab(filterPanel.tabName, filterPanel.component)
+
+            filterPanel.addFilterChangeListener {
+                filterPanel.updateTabState()
+                selectedIndex = i
+            }
+        }
+
+        attachPopupMenu { event ->
+            val tabIndex = indexAtLocation(event.x, event.y)
+            if (tabIndex == -1) return@attachPopupMenu null
+
+            JPopupMenu().apply {
+                add(
+                    Action("Reset") {
+                        filterPanels[tabIndex].reset()
+                    },
+                )
+            }
+        }
+    }
+
+    private fun FilterPanel<*>.updateTabState() {
+        val index = indexOfComponent(component)
+        if (isFilterApplied()) {
+            setBackgroundAt(index, javax.swing.UIManager.getColor("TabbedPane.focusColor"))
+            setTitleAt(index, "$tabName *")
+        } else {
+            setBackgroundAt(index, javax.swing.UIManager.getColor("TabbedPane.background"))
+            setTitleAt(index, tabName)
+        }
+    }
+
+    override fun updateUI() {
+        super.updateUI()
+        @Suppress("UNNECESSARY_SAFE_CALL")
+        filterPanels?.forEach {
+            it.updateTabState()
+        }
+    }
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/LevelPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/LevelPanel.kt
@@ -7,17 +7,13 @@ import io.github.inductiveautomation.kindling.utils.Column
 import io.github.inductiveautomation.kindling.utils.FilterList
 import io.github.inductiveautomation.kindling.utils.FilterModel
 import io.github.inductiveautomation.kindling.utils.FlatScrollPane
-import io.github.inductiveautomation.kindling.utils.add
 import io.github.inductiveautomation.kindling.utils.getAll
 import javax.swing.JComponent
 import javax.swing.JPopupMenu
-import javax.swing.event.EventListenerList
 
-internal class LevelPanel(rawData: List<LogEvent>) : FilterPanel<LogEvent> {
+internal class LevelPanel(rawData: List<LogEvent>) : FilterPanel<LogEvent>() {
     private val filterList: FilterList = FilterList()
     override val component: JComponent = FlatScrollPane(filterList)
-
-    private val listenerList = EventListenerList()
 
     init {
         filterList.setModel(FilterModel(rawData.groupingBy { it.level?.name }.eachCount()))
@@ -25,17 +21,14 @@ internal class LevelPanel(rawData: List<LogEvent>) : FilterPanel<LogEvent> {
 
         filterList.checkBoxListSelectionModel.addListSelectionListener { e ->
             if (!e.valueIsAdjusting) {
-                listenerList.getAll<FilterChangeListener>().forEach(FilterChangeListener::filterChanged)
+                listeners.getAll<FilterChangeListener>().forEach(FilterChangeListener::filterChanged)
             }
         }
     }
 
     override val tabName: String = "Level"
     override fun isFilterApplied() = filterList.checkBoxListSelectedValues.size != filterList.model.size - 1
-    override fun filter(event: LogEvent): Boolean = event.level?.name in filterList.checkBoxListSelectedValues
-    override fun addFilterChangeListener(listener: FilterChangeListener) {
-        listenerList.add(listener)
-    }
+    override fun filter(item: LogEvent): Boolean = item.level?.name in filterList.checkBoxListSelectedValues
 
     override fun customizePopupMenu(menu: JPopupMenu, column: Column<out LogEvent, *>, event: LogEvent) {
         val level = event.level

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/LevelPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/LevelPanel.kt
@@ -1,5 +1,7 @@
 package io.github.inductiveautomation.kindling.log
 
+import io.github.inductiveautomation.kindling.core.FilterChangeListener
+import io.github.inductiveautomation.kindling.core.FilterPanel
 import io.github.inductiveautomation.kindling.utils.Action
 import io.github.inductiveautomation.kindling.utils.Column
 import io.github.inductiveautomation.kindling.utils.FilterList
@@ -11,7 +13,7 @@ import javax.swing.JComponent
 import javax.swing.JPopupMenu
 import javax.swing.event.EventListenerList
 
-internal class LevelPanel(rawData: List<LogEvent>) : LogFilterPanel {
+internal class LevelPanel(rawData: List<LogEvent>) : FilterPanel<LogEvent> {
     private val filterList: FilterList = FilterList()
     override val component: JComponent = FlatScrollPane(filterList)
 

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
@@ -53,7 +53,6 @@ import javax.swing.SortOrder
 import javax.swing.SwingConstants
 import javax.swing.UIManager
 import kotlin.math.absoluteValue
-import kotlin.properties.Delegates
 import io.github.inductiveautomation.kindling.core.Detail as DetailEvent
 
 class LogPanel(
@@ -187,20 +186,17 @@ class LogPanel(
         add(header, "wrap, growx, spanx 2")
         add(
             JSplitPane(
-                JSplitPane.HORIZONTAL_SPLIT,
-                sidebar,
+                JSplitPane.VERTICAL_SPLIT,
                 JSplitPane(
-                    JSplitPane.VERTICAL_SPLIT,
+                    JSplitPane.HORIZONTAL_SPLIT,
+                    sidebar,
                     tableScrollPane,
-                    details,
                 ).apply {
-                    resizeWeight = 0.6
+                    isOneTouchExpandable = true
+                    dividerLocation = insets.left + 320
                 },
-            ).apply {
-                isOneTouchExpandable = true
-                resizeWeight = 0.1
-            },
-            "push, grow",
+                details,
+            ), "push, grow"
         )
 
         table.apply {
@@ -286,10 +282,8 @@ class LogPanel(
             }
         }
 
-        sidebar.apply {
-            for (filterPanel in filterPanels) {
-                filterPanel.addFilterChangeListener(::updateData)
-            }
+        sidebar.filterPanels.forEach { filterPanel ->
+            filterPanel.addFilterChangeListener(::updateData)
         }
 
         ShowFullLoggerNames.addChangeListener {
@@ -394,7 +388,7 @@ class LogPanel(
     }
 
     private class Header(private val totalRows: Int) : JPanel(MigLayout("ins 0, fill, hidemode 3")) {
-        private val events = JLabel("$totalRows (of $totalRows) events")
+        private val events = JLabel("Showing $totalRows of $totalRows events")
 
         val search = JXSearchField("Search")
 
@@ -427,9 +421,11 @@ class LogPanel(
             add(search, "width 300, gap unrelated")
         }
 
-        var displayedRows by Delegates.observable(totalRows) { _, _, newValue ->
-            events.text = "$newValue (of $totalRows) events"
-        }
+        var displayedRows = totalRows
+            set(value) {
+                field = value
+                events.text = "Showing $value of $totalRows events"
+            }
     }
 
 

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/MDCPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/MDCPanel.kt
@@ -1,6 +1,8 @@
 package io.github.inductiveautomation.kindling.log
 
 import com.formdev.flatlaf.extras.FlatSVGIcon
+import io.github.inductiveautomation.kindling.core.FilterChangeListener
+import io.github.inductiveautomation.kindling.core.FilterPanel
 import io.github.inductiveautomation.kindling.core.Kindling.SECONDARY_ACTION_ICON_SCALE
 import io.github.inductiveautomation.kindling.log.MDCTableModel.MDCColumns
 import io.github.inductiveautomation.kindling.utils.Action
@@ -26,7 +28,7 @@ import javax.swing.JPanel
 import javax.swing.JPopupMenu
 import javax.swing.table.AbstractTableModel
 
-internal class MDCPanel(events: List<SystemLogEvent>) : JPanel(MigLayout("ins 0, fill")), LogFilterPanel {
+internal class MDCPanel(events: List<SystemLogEvent>) : JPanel(MigLayout("ins 0, fill")), FilterPanel<LogEvent> {
     private val allMDCs = events.flatMap(SystemLogEvent::mdc)
 
     private val countByKey = allMDCs

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/MDCPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/MDCPanel.kt
@@ -10,7 +10,6 @@ import io.github.inductiveautomation.kindling.utils.Column
 import io.github.inductiveautomation.kindling.utils.ColumnList
 import io.github.inductiveautomation.kindling.utils.FlatScrollPane
 import io.github.inductiveautomation.kindling.utils.ReifiedJXTable
-import io.github.inductiveautomation.kindling.utils.add
 import io.github.inductiveautomation.kindling.utils.attachPopupMenu
 import io.github.inductiveautomation.kindling.utils.configureCellRenderer
 import io.github.inductiveautomation.kindling.utils.getAll
@@ -21,14 +20,13 @@ import java.util.Vector
 import javax.swing.DefaultComboBoxModel
 import javax.swing.JButton
 import javax.swing.JComboBox
-import javax.swing.JComponent
 import javax.swing.JMenu
 import javax.swing.JMenuItem
 import javax.swing.JPanel
 import javax.swing.JPopupMenu
 import javax.swing.table.AbstractTableModel
 
-internal class MDCPanel(events: List<SystemLogEvent>) : JPanel(MigLayout("ins 0, fill")), FilterPanel<LogEvent> {
+internal class MDCPanel(events: List<SystemLogEvent>) : FilterPanel<LogEvent>() {
     private val allMDCs = events.flatMap(SystemLogEvent::mdc)
 
     private val countByKey = allMDCs
@@ -119,27 +117,31 @@ internal class MDCPanel(events: List<SystemLogEvent>) : JPanel(MigLayout("ins 0,
         }
 
         tableModel.addTableModelListener {
-            listenerList.getAll<FilterChangeListener>().forEach(FilterChangeListener::filterChanged)
+            listeners.getAll<FilterChangeListener>().forEach(FilterChangeListener::filterChanged)
         }
     }
 
+    override val component = JPanel(MigLayout("ins 0, fill"))
+
     init {
-        add(keyCombo, "growx, wrap, wmax 100%")
-        add(valueCombo, "growx, wrap, wmax 100%")
-        add(
-            JButton(removeFilter).apply {
-                hideActionText = true
-            },
-            "align right, split",
-        )
-        add(JButton(addFilter), "gapx 2")
-        add(
-            JButton(removeAllFilters).apply {
-                hideActionText = true
-            },
-            "gapx 2",
-        )
-        add(FlatScrollPane(filterTable), "newline, pushy, grow")
+        component.apply {
+            add(keyCombo, "growx, wrap, wmax 100%")
+            add(valueCombo, "growx, wrap, wmax 100%")
+            add(
+                JButton(removeFilter).apply {
+                    hideActionText = true
+                },
+                "align right, split",
+            )
+            add(JButton(addFilter), "gapx 2")
+            add(
+                JButton(removeAllFilters).apply {
+                    hideActionText = true
+                },
+                "gapx 2",
+            )
+            add(FlatScrollPane(filterTable), "newline, pushy, grow")
+        }
 
         filterTable.attachPopupMenu { mouseEvent ->
             val rowAtPoint = rowAtPoint(mouseEvent.point)
@@ -155,15 +157,9 @@ internal class MDCPanel(events: List<SystemLogEvent>) : JPanel(MigLayout("ins 0,
 
     override fun isFilterApplied(): Boolean = tableModel.data.isNotEmpty()
 
-    override val component: JComponent = this
-
     override val tabName: String = "MDC"
 
-    override fun filter(event: LogEvent): Boolean = tableModel.filter(event)
-
-    override fun addFilterChangeListener(listener: FilterChangeListener) {
-        listenerList.add(listener)
-    }
+    override fun filter(item: LogEvent): Boolean = tableModel.filter(item)
 
     override fun customizePopupMenu(menu: JPopupMenu, column: Column<out LogEvent, *>, event: LogEvent) {
         if (column == SystemLogColumns.Message && (event as SystemLogEvent).mdc.isNotEmpty()) {
@@ -198,9 +194,9 @@ data class MDCTableRow(
     val value: String?,
     var inclusive: Boolean = true,
 ) : LogFilter {
-    override fun filter(event: LogEvent): Boolean {
-        check(event is SystemLogEvent)
-        val any = event.mdc.any { (key, value) ->
+    override fun filter(item: LogEvent): Boolean {
+        check(item is SystemLogEvent)
+        val any = item.mdc.any { (key, value) ->
             this.key == key && this.value?.equals(value) == true
         }
         return if (inclusive) any else !any
@@ -238,11 +234,11 @@ class MDCTableModel : AbstractTableModel(), LogFilter {
         }
     }
 
-    override fun filter(event: LogEvent): Boolean {
-        return when (event) {
+    override fun filter(item: LogEvent): Boolean {
+        return when (item) {
             is WrapperLogEvent -> true
             is SystemLogEvent -> _data.isEmpty() || _data.any { row ->
-                row.filter(event)
+                row.filter(item)
             }
         }
     }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/NamePanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/NamePanel.kt
@@ -8,16 +8,14 @@ import io.github.inductiveautomation.kindling.utils.Column
 import io.github.inductiveautomation.kindling.utils.FilterList
 import io.github.inductiveautomation.kindling.utils.FilterModel
 import io.github.inductiveautomation.kindling.utils.FlatScrollPane
-import io.github.inductiveautomation.kindling.utils.add
 import io.github.inductiveautomation.kindling.utils.getAll
 import net.miginfocom.swing.MigLayout
 import javax.swing.ButtonGroup
-import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.JPopupMenu
 import javax.swing.JToggleButton
 
-internal class NamePanel(events: List<LogEvent>) : JPanel(MigLayout("ins 0, fill")), FilterPanel<LogEvent> {
+internal class NamePanel(events: List<LogEvent>) : FilterPanel<LogEvent>() {
     private val countByLogger = events.groupingBy(LogEvent::logger).eachCount()
 
     private fun getSortKey(key: Any?): String {
@@ -36,6 +34,8 @@ internal class NamePanel(events: List<LogEvent>) : JPanel(MigLayout("ins 0, fill
         setModel(FilterModel(countByLogger, ::getSortKey))
     }
 
+    override val component = JPanel(MigLayout("ins 0, fill"))
+
     init {
         ShowFullLoggerNames.addChangeListener {
             filterList.model = filterList.model.copy(filterList.comparator)
@@ -45,30 +45,26 @@ internal class NamePanel(events: List<LogEvent>) : JPanel(MigLayout("ins 0, fill
         for (sortAction in filterList.sortActions) {
             val sortToggle = JToggleButton(sortAction)
             bg.add(sortToggle)
-            add(sortToggle, "split, gapx 2")
+            component.add(sortToggle, "split, gapx 2")
         }
 
-        add(FlatScrollPane(filterList), "newline, push, grow")
+        component.add(FlatScrollPane(filterList), "newline, push, grow")
 
         filterList.selectAll()
         filterList.checkBoxListSelectionModel.addListSelectionListener { event ->
             if (!event.valueIsAdjusting) {
-                listenerList.getAll<FilterChangeListener>().forEach(FilterChangeListener::filterChanged)
+                listeners.getAll<FilterChangeListener>().forEach(FilterChangeListener::filterChanged)
             }
         }
     }
 
-    override val component: JComponent = this
+
     override val tabName: String = "Logger"
 
     override fun isFilterApplied(): Boolean = filterList.checkBoxListSelectedIndices.size < filterList.model.size - 1
 
-    override fun addFilterChangeListener(listener: FilterChangeListener) {
-        listenerList.add(listener)
-    }
-
-    override fun filter(event: LogEvent): Boolean {
-        return event.logger in filterList.checkBoxListSelectedValues
+    override fun filter(item: LogEvent): Boolean {
+        return item.logger in filterList.checkBoxListSelectedValues
     }
 
     override fun customizePopupMenu(

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/NamePanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/NamePanel.kt
@@ -1,5 +1,7 @@
 package io.github.inductiveautomation.kindling.log
 
+import io.github.inductiveautomation.kindling.core.FilterChangeListener
+import io.github.inductiveautomation.kindling.core.FilterPanel
 import io.github.inductiveautomation.kindling.core.Kindling.Preferences.General.ShowFullLoggerNames
 import io.github.inductiveautomation.kindling.utils.Action
 import io.github.inductiveautomation.kindling.utils.Column
@@ -15,7 +17,7 @@ import javax.swing.JPanel
 import javax.swing.JPopupMenu
 import javax.swing.JToggleButton
 
-internal class NamePanel(events: List<LogEvent>) : JPanel(MigLayout("ins 0, fill")), LogFilterPanel {
+internal class NamePanel(events: List<LogEvent>) : JPanel(MigLayout("ins 0, fill")), FilterPanel<LogEvent> {
     private val countByLogger = events.groupingBy(LogEvent::logger).eachCount()
 
     private fun getSortKey(key: Any?): String {

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/ThreadPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/ThreadPanel.kt
@@ -1,5 +1,7 @@
 package io.github.inductiveautomation.kindling.log
 
+import io.github.inductiveautomation.kindling.core.FilterChangeListener
+import io.github.inductiveautomation.kindling.core.FilterPanel
 import io.github.inductiveautomation.kindling.utils.Action
 import io.github.inductiveautomation.kindling.utils.Column
 import io.github.inductiveautomation.kindling.utils.FilterList
@@ -14,7 +16,7 @@ import javax.swing.JPanel
 import javax.swing.JPopupMenu
 import javax.swing.JToggleButton
 
-internal class ThreadPanel(events: List<LogEvent>) : JPanel(MigLayout("ins 0, fill")), LogFilterPanel {
+internal class ThreadPanel(events: List<LogEvent>) : JPanel(MigLayout("ins 0, fill")), FilterPanel<LogEvent> {
     private val filterList = FilterList().apply {
         setModel(FilterModel(events.groupingBy { (it as SystemLogEvent).thread }.eachCount()))
     }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/ThreadPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/ThreadPanel.kt
@@ -7,49 +7,43 @@ import io.github.inductiveautomation.kindling.utils.Column
 import io.github.inductiveautomation.kindling.utils.FilterList
 import io.github.inductiveautomation.kindling.utils.FilterModel
 import io.github.inductiveautomation.kindling.utils.FlatScrollPane
-import io.github.inductiveautomation.kindling.utils.add
 import io.github.inductiveautomation.kindling.utils.getAll
 import net.miginfocom.swing.MigLayout
 import javax.swing.ButtonGroup
-import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.JPopupMenu
 import javax.swing.JToggleButton
 
-internal class ThreadPanel(events: List<LogEvent>) : JPanel(MigLayout("ins 0, fill")), FilterPanel<LogEvent> {
+internal class ThreadPanel(events: List<LogEvent>) : FilterPanel<LogEvent>() {
     private val filterList = FilterList().apply {
         setModel(FilterModel(events.groupingBy { (it as SystemLogEvent).thread }.eachCount()))
     }
+
+    override val component = JPanel(MigLayout("ins 0, fill"))
+    override val tabName: String = "Thread"
 
     init {
         val bg = ButtonGroup()
         for (sortAction in filterList.sortActions) {
             val sortToggle = JToggleButton(sortAction)
             bg.add(sortToggle)
-            add(sortToggle, "split, gapx 2")
+            component.add(sortToggle, "split, gapx 2")
         }
 
-        add(FlatScrollPane(filterList), "newline, push, grow")
+        component.add(FlatScrollPane(filterList), "newline, push, grow")
 
         filterList.selectAll()
         filterList.checkBoxListSelectionModel.addListSelectionListener { event ->
             if (!event.valueIsAdjusting) {
-                listenerList.getAll<FilterChangeListener>().forEach(FilterChangeListener::filterChanged)
+                listeners.getAll<FilterChangeListener>().forEach(FilterChangeListener::filterChanged)
             }
         }
     }
 
-    override val component: JComponent = this
-    override val tabName: String = "Thread"
-
     override fun isFilterApplied(): Boolean = filterList.checkBoxListSelectedIndices.size < filterList.model.size - 1
 
-    override fun addFilterChangeListener(listener: FilterChangeListener) {
-        listenerList.add(listener)
-    }
-
-    override fun filter(event: LogEvent): Boolean {
-        return (event as SystemLogEvent).thread in filterList.checkBoxListSelectedValues
+    override fun filter(item: LogEvent): Boolean {
+        return (item as SystemLogEvent).thread in filterList.checkBoxListSelectedValues
     }
 
     override fun customizePopupMenu(

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/TimePanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/TimePanel.kt
@@ -1,5 +1,7 @@
 package io.github.inductiveautomation.kindling.log
 
+import io.github.inductiveautomation.kindling.core.FilterChangeListener
+import io.github.inductiveautomation.kindling.core.FilterPanel
 import io.github.inductiveautomation.kindling.core.Kindling.Preferences.UI.Theme
 import io.github.inductiveautomation.kindling.log.LogViewer.TimeStampFormatter
 import io.github.inductiveautomation.kindling.utils.Action
@@ -39,7 +41,7 @@ import javax.swing.border.LineBorder
 internal class TimePanel(
     private val lowerBound: Instant,
     private val upperBound: Instant,
-) : JPanel(MigLayout("ins 0, fill, wrap 1")), LogFilterPanel {
+) : JPanel(MigLayout("ins 0, fill, wrap 1")), FilterPanel<LogEvent> {
     private var coveredRange: ClosedRange<Instant> = lowerBound..upperBound
     private val initialRange = coveredRange
 

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/TimePanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/TimePanel.kt
@@ -7,7 +7,6 @@ import io.github.inductiveautomation.kindling.log.LogViewer.TimeStampFormatter
 import io.github.inductiveautomation.kindling.utils.Action
 import io.github.inductiveautomation.kindling.utils.Column
 import io.github.inductiveautomation.kindling.utils.EmptyBorder
-import io.github.inductiveautomation.kindling.utils.add
 import io.github.inductiveautomation.kindling.utils.getAll
 import net.miginfocom.swing.MigLayout
 import org.jdesktop.swingx.JXDatePicker
@@ -41,7 +40,7 @@ import javax.swing.border.LineBorder
 internal class TimePanel(
     private val lowerBound: Instant,
     private val upperBound: Instant,
-) : JPanel(MigLayout("ins 0, fill, wrap 1")), FilterPanel<LogEvent> {
+) :  FilterPanel<LogEvent>() {
     private var coveredRange: ClosedRange<Instant> = lowerBound..upperBound
     private val initialRange = coveredRange
 
@@ -52,16 +51,22 @@ internal class TimePanel(
         reset()
     }
 
+    override val tabName: String = "Time"
+
+    override val component = JPanel(MigLayout("ins 0, fill, wrap 1"))
+
     init {
-        add(startSelector, "pushx, growx")
-        add(
-            JLabel("To").apply {
-                horizontalAlignment = SwingConstants.CENTER
-            },
-            "align center, growx",
-        )
-        add(endSelector, "pushx, growx")
-        add(JButton(resetRange), "top, right, pushy")
+        component.apply {
+            add(startSelector, "pushx, growx")
+            add(
+                JLabel("To").apply {
+                    horizontalAlignment = SwingConstants.CENTER
+                },
+                "align center, growx",
+            )
+            add(endSelector, "pushx, growx")
+            add(JButton(resetRange), "top, right, pushy")
+        }
 
         startSelector.addPropertyChangeListener("time") {
             updateCoveredRange()
@@ -71,24 +76,15 @@ internal class TimePanel(
         }
     }
 
+    override fun isFilterApplied(): Boolean = coveredRange != initialRange
+
     private fun updateCoveredRange() {
         coveredRange = startSelector.time..endSelector.time
 
-        listenerList.getAll<FilterChangeListener>().forEach(FilterChangeListener::filterChanged)
+        listeners.getAll<FilterChangeListener>().forEach(FilterChangeListener::filterChanged)
     }
 
-    override fun isFilterApplied(): Boolean = coveredRange != initialRange
-
-    override val tabName: String = "Time"
-
-    override val component: JComponent = this
-
-    override fun filter(event: LogEvent): Boolean = event.timestamp in coveredRange
-
-    override fun addFilterChangeListener(listener: FilterChangeListener) {
-        listenerList.add(listener)
-    }
-
+    override fun filter(item: LogEvent): Boolean = item.timestamp in coveredRange
     override fun customizePopupMenu(
         menu: JPopupMenu,
         column: Column<out LogEvent, *>,

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/thread/PoolPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/thread/PoolPanel.kt
@@ -1,0 +1,44 @@
+package io.github.inductiveautomation.kindling.thread
+
+import io.github.inductiveautomation.kindling.core.FilterChangeListener
+import io.github.inductiveautomation.kindling.core.FilterPanel
+import io.github.inductiveautomation.kindling.utils.Column
+import io.github.inductiveautomation.kindling.utils.FilterList
+import io.github.inductiveautomation.kindling.utils.FlatScrollPane
+import io.github.inductiveautomation.kindling.utils.getAll
+import net.miginfocom.swing.MigLayout
+import javax.swing.JPanel
+import javax.swing.JPopupMenu
+
+class PoolPanel : FilterPanel<io.github.inductiveautomation.kindling.thread.model.Thread?>() {
+    override val tabName = "Pool"
+
+    val poolList = FilterList { it?.toString() ?: "(No Pool)" }
+
+    private val sortButtons = poolList.createSortButtons()
+
+    override val component = JPanel(MigLayout("fill, gap 5")).apply {
+        val sortGroupEnumeration = sortButtons.elements
+        add(sortGroupEnumeration.nextElement(), "split ${sortButtons.buttonCount}, flowx")
+        for (element in sortGroupEnumeration) {
+            add(element, "gapx 2")
+        }
+        add(FlatScrollPane(poolList), "newline, push, grow")
+    }
+
+    init {
+        poolList.checkBoxListSelectionModel.addListSelectionListener { e ->
+            if (!e.valueIsAdjusting) {
+                listeners.getAll<FilterChangeListener>().forEach(FilterChangeListener::filterChanged)
+            }
+        }
+    }
+
+    override fun isFilterApplied(): Boolean = poolList.checkBoxListSelectedValues.size != poolList.model.size - 1
+
+    override fun reset() = poolList.selectAll()
+
+    override fun filter(item: io.github.inductiveautomation.kindling.thread.model.Thread?): Boolean = item?.pool in poolList.checkBoxListSelectedValues
+
+    override fun customizePopupMenu(menu: JPopupMenu, column: Column<out io.github.inductiveautomation.kindling.thread.model.Thread?, *>, event: io.github.inductiveautomation.kindling.thread.model.Thread?) = Unit
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/thread/StatePanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/thread/StatePanel.kt
@@ -1,0 +1,33 @@
+package io.github.inductiveautomation.kindling.thread
+
+import io.github.inductiveautomation.kindling.core.FilterChangeListener
+import io.github.inductiveautomation.kindling.core.FilterPanel
+import io.github.inductiveautomation.kindling.utils.Column
+import io.github.inductiveautomation.kindling.utils.FilterList
+import io.github.inductiveautomation.kindling.utils.getAll
+import javax.swing.JPopupMenu
+
+class StatePanel : FilterPanel<io.github.inductiveautomation.kindling.thread.model.Thread?>() {
+    val stateList = FilterList()
+    override val tabName = "State"
+
+    override val component = stateList
+
+    init {
+        stateList.selectAll()
+
+        stateList.checkBoxListSelectionModel.addListSelectionListener { e ->
+            if (!e.valueIsAdjusting) {
+                listeners.getAll<FilterChangeListener>().forEach(FilterChangeListener::filterChanged)
+            }
+        }
+    }
+
+    override fun isFilterApplied(): Boolean = stateList.checkBoxListSelectedValues.size != stateList.model.size - 1
+
+    override fun reset() = stateList.selectAll()
+
+    override fun filter(item: io.github.inductiveautomation.kindling.thread.model.Thread?): Boolean = item?.state?.name in stateList.checkBoxListSelectedValues
+
+    override fun customizePopupMenu(menu: JPopupMenu, column: Column<out io.github.inductiveautomation.kindling.thread.model.Thread?, *>, event: io.github.inductiveautomation.kindling.thread.model.Thread?) = Unit
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/thread/SystemPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/thread/SystemPanel.kt
@@ -1,0 +1,48 @@
+package io.github.inductiveautomation.kindling.thread
+
+import io.github.inductiveautomation.kindling.core.FilterChangeListener
+import io.github.inductiveautomation.kindling.core.FilterPanel
+import io.github.inductiveautomation.kindling.thread.model.Thread
+import io.github.inductiveautomation.kindling.utils.Column
+import io.github.inductiveautomation.kindling.utils.FilterList
+import io.github.inductiveautomation.kindling.utils.FlatScrollPane
+import io.github.inductiveautomation.kindling.utils.getAll
+import net.miginfocom.swing.MigLayout
+import javax.swing.JPanel
+import javax.swing.JPopupMenu
+
+class SystemPanel : FilterPanel<Thread?>() {
+    override val tabName = "System"
+
+    val systemList = FilterList { it?.toString() ?: "Unassigned" }
+
+    private val sortButtons = systemList.createSortButtons()
+
+    override val component = JPanel(MigLayout("fill, gap 5")).apply {
+        val sortGroupEnumeration = sortButtons.elements
+        add(sortGroupEnumeration.nextElement(), "split ${sortButtons.buttonCount}, flowx")
+        for (element in sortGroupEnumeration) {
+            add(element, "gapx 2")
+        }
+        add(FlatScrollPane(systemList), "newline, push, grow")
+    }
+
+
+    init {
+        systemList.selectAll()
+
+        systemList.checkBoxListSelectionModel.addListSelectionListener { e ->
+            if (!e.valueIsAdjusting) {
+                listeners.getAll<FilterChangeListener>().forEach(FilterChangeListener::filterChanged)
+            }
+        }
+    }
+
+    override fun isFilterApplied(): Boolean = systemList.checkBoxListSelectedValues.size != systemList.model.size - 1
+
+    override fun reset() = systemList.selectAll()
+
+    override fun filter(item: Thread?): Boolean = item?.system in systemList.checkBoxListSelectedValues
+
+    override fun customizePopupMenu(menu: JPopupMenu, column: Column<out Thread?, *>, event: Thread?) = Unit
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/FilterList.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/FilterList.kt
@@ -8,6 +8,8 @@ import io.github.inductiveautomation.kindling.core.Kindling.SECONDARY_ACTION_ICO
 import io.github.inductiveautomation.kindling.utils.FilterComparator.ByCountDescending
 import java.text.DecimalFormat
 import javax.swing.AbstractListModel
+import javax.swing.ButtonGroup
+import javax.swing.JToggleButton
 import javax.swing.ListModel
 
 data class FilterModelEntry(
@@ -186,4 +188,23 @@ class FilterList(
     ) {
         var comparator: FilterComparator by actionValue("filterComparator", comparator)
     }
+
+    fun createSortButtons(vararg comparators: FilterComparator): ButtonGroup = ButtonGroup().apply {
+        val actions = if (comparators.isEmpty()) sortActions else comparators.map(::SortAction)
+
+        for (sortAction in actions) {
+            add(
+                JToggleButton(
+                    Action(
+                        description = sortAction.description,
+                        icon = sortAction.icon,
+                        selected = sortAction.selected,
+                    ) { e ->
+                        sortAction.actionPerformed(e)
+                    },
+                ),
+            )
+        }
+    }
 }
+


### PR DESCRIPTION
Threads and Logs now have the same UI (and pretty similar implementations) for filtering.

Genericized FilterList and FilterPanel classes
Thread view has an indicator for number of visible threads, just like logs
Moved around the split panes in log viewer so that it's the same as thread viewer.